### PR TITLE
Added missing dependency.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added missing dependency.
+  [Julian Infanger]
 
 
 1.2 (2013-05-10)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(name='ftw.geo',
 
       install_requires=[
         'setuptools',
+        'geopy',
         'collective.geo.settings',
         'collective.geo.openlayers',
         'collective.geo.geographer',


### PR DESCRIPTION
@lukasgraf I've added `geopy` as dependency, to prevent `ImportError: No module named geopy`
