### PR TITLE
Fix removing coordinates if no location is given.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- Fix removing coordinates if no location is given.
+  If you remove an existing address from an object, the handler is now
+  removing the coordinates too. This causes that the map will no longer be
+  visible on the object.
+  [elioschmutz]
+
 - Restrict versions of some dependencies so they don't pull in Plone 5.
   [mbaechtold]
 

--- a/ftw/geo/handlers.py
+++ b/ftw/geo/handlers.py
@@ -140,6 +140,7 @@ def geocodeAddressHandler(obj, event):
         return
 
     location = location_adapter.getLocationString()
+    geo_manager = queryAdapter(obj, IGeoManager)
 
     if location:
         ann = queryAdapter(obj, IAnnotations)
@@ -151,9 +152,11 @@ def geocodeAddressHandler(obj, event):
                 _place, coords, msg = geocoding_result
                 if msg:
                     display_status_message(msg)
-                geo_manager = queryAdapter(obj, IGeoManager)
                 geo_manager.setCoordinates('Point', (coords[1], coords[0]))
                 # Update the stored location
                 ann[LOCATION_KEY] = location
+
+    elif not location and geo_manager:
+        geo_manager.removeCoordinates()
 
     noLongerProvides(request, IGeoCoding)

--- a/ftw/geo/tests/test_archetypes.py
+++ b/ftw/geo/tests/test_archetypes.py
@@ -77,3 +77,20 @@ class TestArchetypesEvents(TestCase):
 
         self.assertEquals(('Point', (47.36864, 8.53918)),
                           IGeoManager(obj).getCoordinates())
+
+    @browsing
+    def test_delete_geocoding_if_address_removed(self, browser):
+        browser.login().open()
+        factoriesmenu.add('Page')
+
+        with ExpectGeocodingRequest():
+            browser.fill({'Title': 'Bern, Switzerland'}).submit()
+
+        statusmessages.assert_no_error_messages()
+        obj = self.portal.get('bern-switzerland')
+        obj.schema.get('title').required = False
+
+        browser.find('Edit').click()
+        browser.fill({'Title': ''}).submit()
+
+        self.assertEquals((None, None), IGeoManager(obj).getCoordinates())

--- a/ftw/geo/tests/test_dexterity.py
+++ b/ftw/geo/tests/test_dexterity.py
@@ -27,7 +27,7 @@ class IAddress(Interface):
 
 class IAddressSchema(form.Schema):
 
-    address = schema.Text(title=u'Address')
+    address = schema.Text(title=u'Address', required=False)
 
 
 class AddressLocationAdapter(object):
@@ -97,3 +97,20 @@ class TestDexterityEvents(TestCase):
 
         self.assertEquals(('Point', (47.36864, 8.53918)),
                           IGeoManager(obj).getCoordinates())
+
+    @browsing
+    def test_delete_geocoding_if_address_removed(self, browser):
+        browser.login().open()
+        factoriesmenu.add('Address')
+        with ExpectGeocodingRequest():
+            browser.fill({'Address': 'Bern, Switzerland'}).submit()
+        statusmessages.assert_no_error_messages()
+
+        obj = self.portal.get('address')
+        self.assertEquals(('Point', (7.444608, 46.947922)),
+                          IGeoManager(obj).getCoordinates())
+
+        browser.find('Edit').click()
+        browser.fill({'Address': ''}).submit()
+
+        self.assertEquals((None, None), IGeoManager(obj).getCoordinates())

--- a/ftw/geo/tests/test_geocoding.py
+++ b/ftw/geo/tests/test_geocoding.py
@@ -145,7 +145,7 @@ class TestGeocoding(MockTestCase):
         geomanager_factory = self.mocker.mock()
         self.mock_adapter(geomanager_factory, IGeoManager, (Interface,))
         self.expect(geomanager_factory(self.context)
-                    ).result(geomanager_proxy)
+                    ).result(geomanager_proxy).count(0, None)
         coords = ('Point', MATCH(is_coord_tuple))
         self.expect(geomanager_proxy.setCoordinates(*coords)).count(count)
 


### PR DESCRIPTION
This fix is for an issue if the user is removing an address from an object.

As long as the coordinates are present on the object, the map will be visible too.

This PR is removing the coordinates if the user is removing the address from the object.