### PR TITLE
Fix bug when using ftw.geo in combination with the IReferenceable behavior

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,9 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix bug when using ftw.geo in combination with the IReferenceable behavior.
+  This bug will appear with plone >= 4.3.8
+  [elioschmutz]
 
 1.3.3 (2016-03-30)
 ------------------

--- a/ftw/geo/configure.zcml
+++ b/ftw/geo/configure.zcml
@@ -35,7 +35,7 @@
 
     <subscriber
         for="collective.geo.geographer.interfaces.IGeoreferenceable
-             zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+             zope.lifecycleevent.interfaces.IObjectAddedEvent"
         handler=".handlers.dx"
         />
 

--- a/ftw/geo/tests/test_dexterity.py
+++ b/ftw/geo/tests/test_dexterity.py
@@ -52,10 +52,15 @@ class TestDexterityEvents(TestCase):
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         login(self.portal, TEST_USER_NAME)
 
+        # Because we have a bug if we use ftw.geo in combination
+        # with the IReferenceable behavior, we run all tests with
+        # this behavior.
         fti = DexterityFTI(
             u'Address',
             schema='.'.join((IAddressSchema.__module__, 'IAddressSchema')),
-            klass='.'.join((Address.__module__, 'Address')))
+            klass='.'.join((Address.__module__, 'Address')),
+            behaviors=['plone.app.referenceablebehavior.referenceable.IReferenceable'])
+
         self.portal.portal_types._setObject('Address', fti)
         fti.lookupSchema()
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ tests_require = [
     'zope.configuration',
     'unittest2',
     'transaction',
+    'plone.app.referenceablebehavior',
     'plone.directives.form',
     ]
 


### PR DESCRIPTION
If we use ``ftw.geo`` with objects having the ``IReferenceable`` behavior (https://github.com/plone/plone.app.referenceablebehavior) in Plone >= 4.3.8 it will raise the following error:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.z3cform.layout, line 66, in __call__
  Module plone.z3cform.layout, line 50, in update
  Module plone.dexterity.browser.add, line 118, in update
  Module plone.z3cform.fieldsets.extensible, line 59, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 21, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.add, line 101, in handleAdd
  Module z3c.form.form, line 264, in createAndAdd
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module ftw.geo.handlers, line 118, in dx
  Module ftw.geo.handlers, line 155, in geocodeAddressHandler
  Module collective.geo.contentlocations.geomanager, line 136, in setCoordinates
  Module collective.geo.geographer.geo, line 54, in setGeoInterface
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module plone.app.referenceablebehavior.uidcatalog, line 43, in modified_handler
  Module zope.component.hookable, line 33, in __call__
  Module zope.component.hooks, line 104, in adapter_hook
  Module plone.app.referenceablebehavior.referenceable, line 52, in __init__
  Module Products.CMFCore.utils, line 10, in check_getToolByName
  Module Products.CMFCore.utils, line 120, in getToolByName
AttributeError: reference_catalog
```
while creating the object.

This PR will fix this issue.