### PR TITLE
Fix string interpolation in German translation file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix German translation.
+  [mbaechtold]
 
 1.3.4 (2016-03-30)
 ------------------

--- a/ftw/geo/locales/de/LC_MESSAGES/ftw.geo.po
+++ b/ftw/geo/locales/de/LC_MESSAGES/ftw.geo.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-03-22 11:22+0000\n"
+"POT-Creation-Date: 2016-09-14 12:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,29 +10,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
+
+#: ./ftw/geo/configure.zcml:18
+msgid "collective.geo.* integration"
+msgstr ""
+
+#: ./ftw/geo/configure.zcml:18
+msgid "ftw.geo"
+msgstr ""
 
 #. Default: "More than one location found, chose first match \"${place}\". Please check that coordinates are correct."
-#: ./ftw/geo/handlers.py:44
+#: ./ftw/geo/handlers.py:65
 msgid "msg_multiple_matches"
 msgstr "Mehr als ein Ort gefunden. Es wurde das erste Resultat \"${place}\" gewählt. Prüfen Sie bitte ob die Koordinaten korrekt sind."
 
 #. Default: "Geocoding failed because of a network error."
-#: ./ftw/geo/handlers.py:68
+#: ./ftw/geo/handlers.py:89
 msgid "msg_network_error"
 msgstr "Die Geocodierung konnte aufgrund eines Netzwerkfehlers nicht durchgeführt werden."
 
 #. Default: "Couldn't find a suitable match for location \"${location}\". Please use the \"coordinates\" tab to manually set the correct map loaction."
-#: ./ftw/geo/handlers.py:52
+#: ./ftw/geo/handlers.py:73
 msgid "msg_no_match"
 msgstr "Konnte keinen passenden Treffer für den Ort \"${location}\" finden. Bitte benutzen Sie das Tab \"Koordinaten\", um den Kartenausschnitt manuell zu setzten"
 
 #. Default: "Geocoding failed because daily query limit has been exceeded."
-#: ./ftw/geo/handlers.py:61
+#: ./ftw/geo/handlers.py:82
 msgid "msg_too_many_queries"
 msgstr "Die Geocodierung schlug fehl weil das tägliche Abfragen-Limit überschritten wurde."
 
-#. Default: "Geocoding failed because of an error: ${ecxeption}"
-#: ./ftw/geo/handlers.py:76
+#. Default: "Geocoding failed because of an error: ${exception}"
+#: ./ftw/geo/handlers.py:97
 msgid "msg_unhandled_exception"
 msgstr "Die Geocodierung ist fehlgeschlagen: ${ecxeption}"
+

--- a/ftw/geo/locales/de/LC_MESSAGES/ftw.geo.po
+++ b/ftw/geo/locales/de/LC_MESSAGES/ftw.geo.po
@@ -42,5 +42,5 @@ msgstr "Die Geocodierung schlug fehl weil das tägliche Abfragen-Limit überschr
 #. Default: "Geocoding failed because of an error: ${exception}"
 #: ./ftw/geo/handlers.py:97
 msgid "msg_unhandled_exception"
-msgstr "Die Geocodierung ist fehlgeschlagen: ${ecxeption}"
+msgstr "Die Geocodierung ist fehlgeschlagen: ${exception}"
 

--- a/ftw/geo/locales/ftw.geo.pot
+++ b/ftw/geo/locales/ftw.geo.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-03-22 11:22+0000\n"
+"POT-Creation-Date: 2016-09-14 12:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,33 +12,38 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.geo\n"
+
+#: ./ftw/geo/configure.zcml:18
+msgid "collective.geo.* integration"
+msgstr ""
+
+#: ./ftw/geo/configure.zcml:18
+msgid "ftw.geo"
+msgstr ""
 
 #. Default: "More than one location found, chose first match \"${place}\". Please check that coordinates are correct."
-#: ./ftw/geo/handlers.py:44
+#: ./ftw/geo/handlers.py:65
 msgid "msg_multiple_matches"
 msgstr ""
 
 #. Default: "Geocoding failed because of a network error."
-#: ./ftw/geo/handlers.py:68
+#: ./ftw/geo/handlers.py:89
 msgid "msg_network_error"
 msgstr ""
 
 #. Default: "Couldn't find a suitable match for location \"${location}\". Please use the \"coordinates\" tab to manually set the correct map loaction."
-#: ./ftw/geo/handlers.py:52
+#: ./ftw/geo/handlers.py:73
 msgid "msg_no_match"
 msgstr ""
 
 #. Default: "Geocoding failed because daily query limit has been exceeded."
-#: ./ftw/geo/handlers.py:61
+#: ./ftw/geo/handlers.py:82
 msgid "msg_too_many_queries"
 msgstr ""
 
-#. Default: "Geocoding failed because of an error: ${ecxeption}"
-#: ./ftw/geo/handlers.py:76
+#. Default: "Geocoding failed because of an error: ${exception}"
+#: ./ftw/geo/handlers.py:97
 msgid "msg_unhandled_exception"
 msgstr ""
 


### PR DESCRIPTION
This fixes the variable name in the translation file for the exception message to be inserted correctly.