### PR TITLE
Pass google api key from "IGeoSettings.googleapi" to GoogleV3 (required now)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- Pass google api key from "IGeoSettings.googleapi" to GoogleV3 (required now). [mathias.leimgruber]
+
 - Drop Plone 4.1 support. [jone]
 
 

--- a/ftw/geo/handlers.py
+++ b/ftw/geo/handlers.py
@@ -3,6 +3,7 @@ from collective.geo.contentlocations.interfaces import IGeoManager
 from ftw.geo import _
 from ftw.geo.interfaces import IGeocodableLocation
 from geopy import geocoders
+from plone import api
 from plone.dexterity.interfaces import IDexterityContent
 from plone.memoize import ram
 from Products.Archetypes.interfaces import IBaseObject
@@ -48,10 +49,12 @@ def geocode_location(location):
     been selected.
     """
     msg = None
+    google_api = api.portal.get_registry_record(
+        'collective.geo.settings.interfaces.IGeoSettings.googleapi',
+        default=None,
+    )
 
-    # Google map api v3 does not take any api key
-    # Check GoogleV3 implementation
-    gmgeocoder = geocoders.GoogleV3()
+    gmgeocoder = geocoders.GoogleV3(api_key=google_api)
 
     try:
         results = gmgeocoder.geocode(location, exactly_one=False)

--- a/ftw/geo/testing.py
+++ b/ftw/geo/testing.py
@@ -36,7 +36,6 @@ class GeoLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
-
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.dexterity:default')
 

--- a/ftw/geo/tests/test_geocoding.py
+++ b/ftw/geo/tests/test_geocoding.py
@@ -11,6 +11,7 @@ from mocker import ANY
 from mocker import ARGS
 from mocker import KWARGS
 from mocker import MATCH
+from plone import api
 from plone.memoize import ram
 from plone.registry.interfaces import IRegistry
 from Products.statusmessages.interfaces import IStatusMessage
@@ -79,11 +80,16 @@ class TestGeocoding(MockTestCase):
         provideAdapter(SomeTypeLocationAdapter)
         self.context = None
 
+        self.original_get_registry_record = api.portal.get_registry_record
+        api.portal.get_registry_record = lambda *args, **kwargs: 'mock tests deserve this'
+
     def tearDown(self):
         super(TestGeocoding, self).tearDown()
         self.context = None
         # Invalidate the geocoding cache so tests run in isolation
         ram.global_cache.invalidate('ftw.geo.handlers.geocode_location')
+
+        api.portal.get_registry_record = self.original_get_registry_record
 
     def replace_geopy_geocoders(self, result=None):
         """Replace the geocode method of the Google geocoder with a mock

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name='ftw.geo',
         'collective.geo.kml',
         'collective.geo.mapwidget >= 2.1, < 3.0',
         'plone.app.dexterity',
+        'plone.api',
         'ftw.upgrade',
         ],
 


### PR DESCRIPTION
For reference: this change is copied from https://github.com/collective/collective.geo.mapwidget/commit/e057cbab4c997dd8fb5c0b261aab1dc29b6fe5e4