### PR TITLE
The location adapter may return utf-8 or unicode, so lets use safe_unicode to be sure

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
+- The location adapter may return utf-8 or unicode, so lets use safe_uniode to be sure. [mathias.leimgruber]
+
 - Drop Plone 4.2 support. [mathias.leimgruber]
 
 - Since Version 1.3.6 plone.api 1.5.1 is required. [mathias.leimgruber]

--- a/ftw/geo/handlers.py
+++ b/ftw/geo/handlers.py
@@ -1,4 +1,3 @@
-from collections import Iterable
 from collective.geo.contentlocations.interfaces import IGeoManager
 from ftw.geo import _
 from ftw.geo.interfaces import IGeocodableLocation
@@ -7,6 +6,7 @@ from plone import api
 from plone.dexterity.interfaces import IDexterityContent
 from plone.memoize import ram
 from Products.Archetypes.interfaces import IBaseObject
+from Products.CMFPlone.utils import safe_unicode
 from Products.statusmessages.interfaces import IStatusMessage
 from urllib2 import URLError
 from ZODB.POSException import ConflictError
@@ -77,7 +77,7 @@ def geocode_location(location):
                 default=u'Couldn\'t find a suitable match for location '
                 '"${location}". Please use the "coordinates" tab to manually '
                 'set the correct map loaction.',
-                mapping=dict(location=location.decode('utf-8')))
+                mapping=dict(location=safe_unicode(location)))
         display_status_message(msg)
         return
 


### PR DESCRIPTION

This lead to unicode errors on certain circumstances.
- Depending on the geolocation adapter implementation.
- Depending on geopy and google api response.