### PR TITLE
Catch location not found error location search

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix location not found error raising False exception, leading to a bad error message for the user [Nachtalb]
 
 
 1.4.0 (2019-01-23)

--- a/ftw/geo/handlers.py
+++ b/ftw/geo/handlers.py
@@ -59,6 +59,9 @@ def geocode_location(location):
     try:
         results = gmgeocoder.geocode(location, exactly_one=False)
 
+        if results is None:
+            raise GeocoderQueryError
+
         # geopy < 0.98 does not return a list in every case.
         if not isinstance(results, list):
             results = list(results)


### PR DESCRIPTION
It is possible that the `GoogleV3.geocode(...)` returns `None`. If this happens it means no location was found and we should display a proper error message to the User. For this, we check if it is None and raise the `GeocoderQueryError` error, which is already handled to give the user the correct error. That `None` is returned may be due to a change in the Google Maps API.