### PR TITLE
Move plone5 incompatible dependency to plone4 extra

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move plone5 incompatible dependency to plone4 extra [Nachtalb]
 
 
 1.4.1 (2019-04-01)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@ tests_require = [
     'zope.configuration',
     'unittest2',
     'transaction',
-    'plone.app.referenceablebehavior',
     'plone.directives.form',
-    ]
+]
+
+plone4 = [
+    'plone.app.referenceablebehavior',
+]
 
 setup(name='ftw.geo',
       version=version,
@@ -60,7 +63,8 @@ setup(name='ftw.geo',
         ],
 
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=dict(tests=tests_require,
+                          plone4=plone4),
 
       entry_points='''
       # -*- Entry points: -*-

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,3 +4,6 @@ extends =
     sources.cfg
 
 package-name = ftw.geo
+
+[instance]
+eggs += ftw.geo [plone4]


### PR DESCRIPTION
We put referenceablebehavior into a separate setup part, so we do not need to install it in plone5