### PR TITLE
Pin "ftw.testing" to the 1.x release branch.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ maintainer = 'Lukas Graf'
 
 tests_require = [
     'ftw.testbrowser',
-    'ftw.testing',
+    'ftw.testing<2.0a',
     'mocker',
     'plone.app.testing',
     'plone.testing',


### PR DESCRIPTION
This fixes the failing tests on the `master` branch which is currently on the commit https://github.com/4teamwork/ftw.geo/commit/716088e0da1ce6dda7d00c5d4a10b4e204680997.

We would need to rewrite some of the tests if we would use "ftw.testing" 2.0 a newer. We can do this later.